### PR TITLE
Re-add Matchers#toBe()

### DIFF
--- a/jasmine/jasmine.d.ts
+++ b/jasmine/jasmine.d.ts
@@ -271,6 +271,7 @@ declare module jasmine {
         (expected: any): boolean;
         toEqual(expected: any): boolean;
         toMatch(expected: any): boolean;
+        toBe(expected: any): boolean;
         toBeDefined(): boolean;
         toBeUndefined(): boolean;
         toBeNull(): boolean;


### PR DESCRIPTION
This should not have been removed, the strict-equality check is valuable.